### PR TITLE
Wrap CTA Buttons with Links

### DIFF
--- a/src/components/sections/AboutUs.tsx
+++ b/src/components/sections/AboutUs.tsx
@@ -2,6 +2,8 @@
 import { motion } from "framer-motion";
 import { useInView } from "react-intersection-observer";
 import { LucideCode, LucideZap, LucideHeadphones } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 const services = [
   {
@@ -139,9 +141,12 @@ export default function AboutUs() {
             <p className="text-xl text-white/90 mb-8 leading-relaxed">
               ¿Tienes una idea? Hablemos y veamos cómo la hacemos realidad.
             </p>
-            <button className="inline-flex items-center px-10 py-4 bg-gradient-to-r from-fuchsia-500 to-cyan-500 rounded-full text-white font-semibold text-lg shadow-lg shadow-fuchsia-500/20 transition-all duration-300 hover:scale-105 hover:shadow-xl hover:shadow-fuchsia-500/30 active:scale-95">
-              Empezar mi proyecto
-            </button>
+            <Button
+              asChild
+              className="inline-flex items-center px-10 py-4 bg-gradient-to-r from-fuchsia-500 to-cyan-500 rounded-full text-white font-semibold text-lg shadow-lg shadow-fuchsia-500/20 transition-all duration-300 hover:scale-105 hover:shadow-xl hover:shadow-fuchsia-500/30 active:scale-95"
+            >
+              <Link href="#contacto">Empezar mi proyecto</Link>
+            </Button>
           </div>
         </motion.div>
       </div>

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -10,6 +10,8 @@ import {
   LucideSend,
 } from "lucide-react";
 import { useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 const contactMethods = [
   {
@@ -294,10 +296,15 @@ export default function Contact() {
                 Si necesitas tu proyecto listo ya, podemos ayudarte con tiempos
                 de entrega express.
               </p>
-              <button className="inline-flex items-center px-6 py-3 bg-white/10 border border-white/20 rounded-xl text-white font-semibold transition-all duration-200 hover:bg-white/20 hover:scale-105">
-                Contacto directo
-                <LucideArrowRight className="w-4 h-4 ml-2" />
-              </button>
+              <Button
+                asChild
+                className="inline-flex items-center px-6 py-3 bg-white/10 border border-white/20 rounded-xl text-white font-semibold transition-all duration-200 hover:bg-white/20 hover:scale-105"
+              >
+                <Link href="#contacto">
+                  Contacto directo
+                  <LucideArrowRight className="w-4 h-4 ml-2" />
+                </Link>
+              </Button>
             </div>
           </motion.div>
         </div>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -2,6 +2,7 @@
 import { motion, Variants } from "framer-motion";
 import { useInView } from "react-intersection-observer";
 import Image from "next/image";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { useMemo } from "react";
 
@@ -96,6 +97,7 @@ export default function Hero() {
 
           <motion.div variants={fadeUp} custom={2}>
             <Button
+              asChild
               size="lg"
               className="relative inline-flex items-center justify-center rounded-2xl px-10 py-5 font-semibold transition-all duration-300 shadow-xl hover:scale-105"
               style={{
@@ -104,9 +106,11 @@ export default function Hero() {
                 boxShadow: "0 4px 40px 0 rgba(163, 60, 246, 0.2)",
               }}
             >
-              <span className="relative z-10 text-lg font-bold text-white tracking-wide">
-                Comienza tu proyecto
-              </span>
+              <Link href="#contacto">
+                <span className="relative z-10 text-lg font-bold text-white tracking-wide">
+                  Comienza tu proyecto
+                </span>
+              </Link>
             </Button>
           </motion.div>
         </motion.div>

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -4,6 +4,7 @@ import { motion, Variants } from "framer-motion";
 import { useState, useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 import Image from "next/image";
+import Link from "next/link";
 import {
   Carousel,
   CarouselContent,
@@ -209,6 +210,7 @@ export default function Proyectos() {
                           }}
                         >
                           <Button
+                            asChild
                             size="sm"
                             className="rounded-2xl px-6 py-3 font-semibold shadow-xl"
                             style={{
@@ -216,9 +218,11 @@ export default function Proyectos() {
                                 "linear-gradient(135deg, #d946ef 0%, #9333ea 50%, #3b82f6 100%)",
                             }}
                           >
-                            <span className="text-sm font-bold text-white">
-                              Ver Proyecto →
-                            </span>
+                            <Link href={project.link}>
+                              <span className="text-sm font-bold text-white">
+                                Ver Proyecto →
+                              </span>
+                            </Link>
                           </Button>
                         </div>
                       </div>

--- a/src/components/sections/Services.tsx
+++ b/src/components/sections/Services.tsx
@@ -7,6 +7,8 @@ import {
   LucideRocket,
   LucideArrowUpRight,
 } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 const services = [
   {
@@ -172,9 +174,12 @@ export default function Services() {
           <p className="text-white/60 mb-6 text-lg">
             ¿Listo para transformar tu negocio?
           </p>
-          <button className="px-8 py-4 bg-gradient-to-r from-fuchsia-500 to-cyan-500 rounded-full text-white font-semibold shadow-lg transition-all duration-200 hover:scale-105 active:scale-95">
-            Conversemos sobre tu proyecto
-          </button>
+          <Button
+            asChild
+            className="px-8 py-4 bg-gradient-to-r from-fuchsia-500 to-cyan-500 rounded-full text-white font-semibold shadow-lg transition-all duration-200 hover:scale-105 active:scale-95"
+          >
+            <Link href="#contacto">Conversemos sobre tu proyecto</Link>
+          </Button>
         </motion.div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- use `asChild` Button and Link for hero CTA
- link project buttons to `project.link`
- convert call-to-action buttons in AboutUs, Services and Contact to Button+Link

## Testing
- `npm run lint` *(fails: `next` not found)*
