### PR TITLE
Improve load flow and add missing CTA link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,19 @@
-import React, { Suspense } from "react";
+import React from "react";
 
-const Hero = React.lazy(() => import("@/components/sections/Hero"));
-const Projects = React.lazy(() => import("@/components/sections/Projects"));
-const Services = React.lazy(() => import("@/components/sections/Services"));
-const AboutUs = React.lazy(() => import("@/components/sections/AboutUs"));
-const Contact = React.lazy(() => import("@/components/sections/Contact"));
+import Hero from "@/components/sections/Hero";
+import Projects from "@/components/sections/Projects";
+import Services from "@/components/sections/Services";
+import AboutUs from "@/components/sections/AboutUs";
+import Contact from "@/components/sections/Contact";
 
 export default function Home() {
   return (
     <>
-      <Suspense fallback={<div>Loading...</div>}>
-        <Hero />
-        <Services/>
-        <Projects/>
-        <AboutUs/>
-        <Contact/>
-      </Suspense>
+      <Hero />
+      <Services />
+      <Projects />
+      <AboutUs />
+      <Contact />
     </>
   );
 }

--- a/src/components/sections/Services.tsx
+++ b/src/components/sections/Services.tsx
@@ -153,12 +153,15 @@ export default function Services() {
                     ))}
                   </div>
 
-                  <div className="flex items-center text-white/50 group-hover:text-white/80 transition-colors duration-200">
+                  <Link
+                    href="#contacto"
+                    className="flex items-center text-white/50 group-hover:text-white/80 transition-colors duration-200"
+                  >
                     <span className="text-sm font-medium mr-2">
                       Más información
                     </span>
                     <LucideArrowUpRight className="w-4 h-4 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
-                  </div>
+                  </Link>
                 </div>
               </motion.div>
             )


### PR DESCRIPTION
## Summary
- streamline `Home` page by importing sections directly
- add a missing link in the Services call‑to‑action

## Testing
- `npm run lint` *(fails: `next` not found)*
